### PR TITLE
Sync package.json license field to new license

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "textfield"
     ],
     "author": "Jack Stenglein",
-    "license": "GPL-3.0-only",
+    "license": "MIT",
     "devDependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.0",


### PR DESCRIPTION
The license field declared in the package.json was out of sync with the new license.
This could leave potential users puzzled about the license mismatch