### PR TITLE
fix(SuggestionsOverlay): move Stack layout props to sx for MUI v9 compat

### DIFF
--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -233,7 +233,7 @@ function SuggestionsOverlay<T extends BaseSuggestionData>(props: SuggestionsOver
                         {renderedSuggestions.length > 0
                             ? renderedSuggestions
                             : loading && (
-                                  <Stack justifyContent='center' alignItems='center' height='40vh'>
+                                  <Stack sx={{ justifyContent: 'center', alignItems: 'center', height: '40vh' }}>
                                       <CircularProgress />
                                   </Stack>
                               )}


### PR DESCRIPTION
MUI v9 removed `justifyContent`, `alignItems`, `height` (and other system layout props) as top-level props on `Stack`. Only `direction`, `spacing`, `divider`, and `useFlexGap` remain; everything else must go through `sx`.

On v9 the current `SuggestionsOverlay` loading state triggers:

> Warning: React does not recognize the `justifyContent` prop on a DOM element. [...] `alignItems` [...]

because the props now fall through to the underlying DOM element instead of being translated into CSS.

This PR moves the three layout values into the `sx` prop. No visual or behavioral change on v5/v6/v7 — `sx` has been the recommended API since v5 and works identically on all supported MUI versions.

Ref: [MUI X v9 migration notes](https://mui.com/material-ui/migration/upgrade-to-v9/#system-props)