### PR TITLE
Feature/add images on suggestions

### DIFF
--- a/examples/src/ShowAvatar.tsx
+++ b/examples/src/ShowAvatar.tsx
@@ -1,0 +1,44 @@
+import { Stack, Typography } from '@mui/material';
+import React from 'react';
+import { MentionsTextField } from '../../src';
+import { avatarShowcase } from './data';
+
+export const ShowAvatar = () => {
+    return (
+        <Stack spacing={2.5}>
+            <Stack spacing={0.5}>
+                <Typography variant='h5'>Show Avatar</Typography>
+                <Typography>
+                    Use the showAvatar field on the data source to display an avatar next to each suggestion. Suggestions
+                    with an image will display it; those without will show a fallback avatar with their initials. Use
+                    avatarSx to customize the fallback avatar's background color, text color, size, and more.
+                </Typography>
+            </Stack>
+
+            <Stack direction='row' spacing={2}>
+                <MentionsTextField
+                    label='With Avatars'
+                    fullWidth
+                    dataSources={[
+                        {
+                            data: avatarShowcase,
+                            showAvatar: true,
+                        },
+                    ]}
+                />
+
+                <MentionsTextField
+                    label='Custom Avatar Style'
+                    fullWidth
+                    dataSources={[
+                        {
+                            data: avatarShowcase,
+                            showAvatar: true,
+                            avatarSx: { bgcolor: 'secondary.main', width: 32, height: 32, fontSize: '0.875rem' },
+                        },
+                    ]}
+                />
+            </Stack>
+        </Stack>
+    );
+};

--- a/examples/src/data.ts
+++ b/examples/src/data.ts
@@ -32,3 +32,47 @@ export const mistborn = [
     { id: 'wayne', display: 'Wayne' },
     { id: 'steris', display: 'Steris Colms' },
 ];
+
+export const avatarShowcase = [
+    {
+        id: 'alex-johnson',
+        display: 'Alex Johnson',
+        image: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?q=80&w=200&auto=format&fit=crop',
+    },
+    {
+        id: 'maya-patel',
+        display: 'Maya Patel',
+        image: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?q=80&w=200&auto=format&fit=crop',
+    },
+    {
+        id: 'chris-miller',
+        display: 'Chris Miller',
+        image: 'https://images.unsplash.com/photo-1568602471122-7832951cc4c5?q=80&w=200&auto=format&fit=crop',
+    },
+    {
+        id: 'sofia-torres',
+        display: 'Sofia Torres',
+        image: 'https://images.unsplash.com/photo-1607746882042-944635dfe10e?q=80&w=200&auto=format&fit=crop',
+    },
+    {
+        id: 'sam-rivera',
+        display: 'Sam Rivera',
+        image: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?q=80&w=200&auto=format&fit=crop',
+    },
+    {
+        id: 'leo-chen',
+        display: 'Leo Chen',
+        image: 'https://images.unsplash.com/photo-1527980965255-d3b416303d12?q=80&w=200&auto=format&fit=crop',
+    },
+    {
+        id: 'amara-diallo',
+        display: 'Amara Diallo',
+        image: 'https://images.unsplash.com/photo-1580489944761-15a19d654956?q=80&w=200&auto=format&fit=crop',
+    },
+    { id: 'james-lee', display: 'James Lee' },
+    { id: 'priya', display: 'Priya' },
+    { id: 'tobias-green', display: 'Tobias Green' },
+    { id: 'nadia-osei', display: 'Nadia Osei' },
+    { id: 'fatima-al-hassan', display: 'Fatima Al-Hassan' },
+    { id: 'daniel-park', display: 'Daniel Park' },
+];

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -25,6 +25,7 @@ import { Limitations } from './Limitations';
 import { Multiline } from './Multiline';
 import { MultipleDataSources } from './MultipleDataSources';
 import { Sizes } from './Sizes';
+import { ShowAvatar } from './ShowAvatar';
 import { SlotProps } from './SlotProps';
 import { Trigger } from './Trigger';
 
@@ -66,6 +67,7 @@ const App = () => {
                     <Trigger />
                     <MultipleDataSources />
                     <AppendSpaceOnAdd />
+                    <ShowAvatar />
                     <DisplayTransform />
                     <AsychronousData />
 

--- a/src/Suggestion.tsx
+++ b/src/Suggestion.tsx
@@ -1,6 +1,15 @@
-import { ListItemButton } from '@mui/material';
+import { Avatar, ListItemAvatar, ListItemButton } from '@mui/material';
+import { SxProps, Theme } from '@mui/material/styles';
 import React, { ReactNode, type JSX } from 'react';
 import { BaseSuggestionData, DefaultDisplayTransform, SuggestionData } from './types';
+
+function getInitials(display: string): string {
+    const parts = display.trim().split(/\s+/);
+    if (parts.length >= 2) {
+        return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+    }
+    return display.slice(0, 2).toUpperCase();
+}
 
 interface SuggestionProps<T extends BaseSuggestionData> {
     /** The id of the suggestion. */
@@ -18,6 +27,12 @@ interface SuggestionProps<T extends BaseSuggestionData> {
     /** Whether the suggestion is focused by the user. */
     focused?: boolean;
 
+    /** Whether to show an avatar for this suggestion. Falls back to initials when no image is set. */
+    showAvatar?: boolean;
+
+    /** MUI sx prop applied to the Avatar. Use to customize background color, text color, size, etc. */
+    avatarSx?: SxProps<Theme>;
+
     /** A function to customize the suggestion renderer. */
     renderSuggestion?: (props: SuggestionProps<T>) => JSX.Element;
 
@@ -29,7 +44,7 @@ interface SuggestionProps<T extends BaseSuggestionData> {
 }
 
 function Suggestion<T extends BaseSuggestionData>(props: SuggestionProps<T>): ReactNode {
-    const { renderSuggestion, suggestion, focused, onClick, onMouseEnter } = props;
+    const { renderSuggestion, suggestion, focused, showAvatar, avatarSx, onClick, onMouseEnter } = props;
 
     if (renderSuggestion) {
         return renderSuggestion(props);
@@ -44,6 +59,13 @@ function Suggestion<T extends BaseSuggestionData>(props: SuggestionProps<T>): Re
             onClick={onClick}
             onMouseEnter={onMouseEnter}
         >
+            {showAvatar && (
+                <ListItemAvatar>
+                    <Avatar src={suggestion.image} alt={display} sx={avatarSx}>
+                        {getInitials(display)}
+                    </Avatar>
+                </ListItemAvatar>
+            )}
             {display}
         </ListItemButton>
     );

--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -191,6 +191,8 @@ function SuggestionsOverlay<T extends BaseSuggestionData>(props: SuggestionsOver
                         index={index}
                         suggestion={result}
                         focused={index === focusIndex}
+                        showAvatar={dataSources[queryInfo.childIndex]?.showAvatar}
+                        avatarSx={dataSources[queryInfo.childIndex]?.avatarSx}
                         onClick={() => handleSelect(result, queryInfo)}
                         onMouseEnter={() => handleMouseEnter(index)}
                     />
@@ -198,7 +200,7 @@ function SuggestionsOverlay<T extends BaseSuggestionData>(props: SuggestionsOver
             ],
             [],
         );
-    }, [suggestions, handleSelect, handleMouseEnter, focusIndex]);
+    }, [suggestions, handleSelect, handleMouseEnter, focusIndex, dataSources]);
 
     if (selectionStart === null || selectionStart !== selectionEnd) {
         // The user either is not typing or has highlighted text,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { PopperProps } from '@mui/material';
+import { SxProps, Theme } from '@mui/material/styles';
 
 /**
  * The minimum data of a suggestion.
@@ -9,6 +10,9 @@ export interface BaseSuggestionData {
 
     /** The user-facing display string of the suggestion data. */
     display?: string;
+
+    /** The image url */
+    image?: string;
 }
 
 /**
@@ -90,6 +94,19 @@ export interface SuggestionDataSource<T extends BaseSuggestionData> {
      * @default (id, display) => display || id;
      */
     displayTransform?: (id: string, display?: string) => string;
+
+    /**
+     * Whether to show an avatar for each suggestion in the list. When true, suggestions with an
+     * image will display it; those without will show a fallback avatar with their initials.
+     * @default false
+     */
+    showAvatar?: boolean;
+
+    /**
+     * MUI sx prop applied to the Avatar component when {@link showAvatar} is true.
+     * Use this to customize the background color, text color, size, etc. of the fallback avatar.
+     */
+    avatarSx?: SxProps<Theme>;
 
     /**
      * Callback invokved when a suggestion is selected and added to the TextField.


### PR DESCRIPTION
**Summary**
This PR adds opt-in avatar support to the suggestion list overlay, controlled at the `SuggestionDataSource` level.

- `image` field added to `BaseSuggestionData` — attach a URL to any suggestion item
- `showAvatar` flag on `SuggestionDataSource` — when `true`, every item in that source's list renders an avatar. Items with an `image` display it; items without one fall back to a two-letter initials avatar (first + last name initial, or first two characters for single-word names)
- `avatarSx` on `SuggestionDataSource` — accepts any MUI `SxProps` to customize the avatar's background color, text color, size, etc.

The `showAvatar` flag is intentionally list-level rather than per-item. This keeps the suggestion list visually consistent — either all items reserve the avatar slot, or none do, avoiding misaligned rows when only some items have images.

**New fields**

```
// BaseSuggestionData
image?: string;

// SuggestionDataSource
showAvatar?: boolean;   // default: false
avatarSx?: SxProps<Theme>;
```

**Usage**

```
<MentionsTextField
  dataSources={[{
    data: users,
    showAvatar: true,
    avatarSx: { bgcolor: 'secondary.main', width: 32, height: 32 },
  }]}
/>
```

Test plan

- [ ]  Type `@` and verify suggestions with `image` render the photo avatar
- [ ]  Verify suggestions without `image` render a two-letter initials fallback
- [ ]  Verify `showAvatar: false` (default) renders no avatar column at all
- [ ]  Verify `avatarSx` customizations (bgcolor, size) apply correctly to the fallback avatar
- [ ]  Verify `avatarSx` does not affect items that render an image
- [ ]  Run `npx tsc --noEmit` — no errors
- [ ]  Check the new `ShowAvatar` example in the live demo renders both cases correctly